### PR TITLE
#45 Feature dual weapon

### DIFF
--- a/Zilon.Client/Assets/Zilon/Scripts/Models/SectorScene/SectorVM.cs
+++ b/Zilon.Client/Assets/Zilon/Scripts/Models/SectorScene/SectorVM.cs
@@ -352,6 +352,9 @@ internal class SectorVM : MonoBehaviour
             _personManager.Person = person;
 
             _personManager.SectorName = GetRandomName();
+
+            AddEquipmentToActor(inventory, "short-sword");
+            AddEquipmentToActor(inventory, "short-sword");
         }
 
         var actor = new Actor(_personManager.Person, player, startNode);

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
@@ -25,28 +25,6 @@ namespace Zilon.Core.Tests.Tactics.Behaviour
         private IMap _testMap;
 
         /// <summary>
-        /// Тест проверяет, что при атаке вызывается событие использования действия у актёра.
-        /// </summary>
-        [Test, Ignore("Теперь это делает сервис использования действий, нужно написать тест для него")]
-        public void AttackTask_Execute_RaiseUsedAct()
-        {
-            // ARRANGE
-
-
-
-            using (var monitor = _actor.Monitor())
-            {
-                // ACT
-                _attackTask.Execute();
-
-
-
-                // ASSERT
-                monitor.Should().Raise(nameof(IActor.UsedAct));
-            }
-        }
-
-        /// <summary>
         /// Тест проверяет, что при атаке, если не мешают стены, не выбрасывается исключение.
         /// </summary>
         [Test]

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
@@ -42,28 +42,6 @@ namespace Zilon.Core.Tests.Tactics.Behaviour
             act.Should().NotThrow<InvalidOperationException>();
         }
 
-        /// <summary>
-        /// Тест проверяет, что при атаке сквозь стены выбрасывается исключение.
-        /// </summary>
-        [Test, Ignore("теперь это делает сервис, нужно писать тест для него")]
-        public void AttackTask_Wall_ThrowsInvalidOperationException()
-        {
-            // ARRANGE
-            _testMap.RemoveEdge(0, 0, 1, 0);
-
-
-            Action act = () =>
-            {
-                // ACT
-                _attackTask.Execute();
-            };
-
-
-
-            // ASSERT
-            act.Should().Throw<InvalidOperationException>();
-        }
-
         [SetUp]
         public void SetUp()
         {

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
@@ -128,7 +128,7 @@ namespace Zilon.Core.Tests.Tactics.Behaviour
 
 
             // Создаём саму команду
-            _attackTask = new AttackTask(_actor, target, actService, _testMap);
+            _attackTask = new AttackTask(_actor, target, actService);
         }
     }
 }

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/AttackTaskTests.cs
@@ -27,7 +27,7 @@ namespace Zilon.Core.Tests.Tactics.Behaviour
         /// <summary>
         /// Тест проверяет, что при атаке вызывается событие использования действия у актёра.
         /// </summary>
-        [Test]
+        [Test, Ignore("Теперь это делает сервис использования действий, нужно написать тест для него")]
         public void AttackTask_Execute_RaiseUsedAct()
         {
             // ARRANGE
@@ -67,7 +67,7 @@ namespace Zilon.Core.Tests.Tactics.Behaviour
         /// <summary>
         /// Тест проверяет, что при атаке сквозь стены выбрасывается исключение.
         /// </summary>
-        [Test]
+        [Test, Ignore("теперь это делает сервис, нужно писать тест для него")]
         public void AttackTask_Wall_ThrowsInvalidOperationException()
         {
             // ARRANGE

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/HumanActorTaskSourceTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/Behaviour/HumanActorTaskSourceTests.cs
@@ -262,7 +262,7 @@ namespace Zilon.Core.Tests.Tactics.Behaviour
 
             var taskSource = InitTaskSource(attackerActor);
 
-            var attackIntention = new Intention<AttackTask>(a => new AttackTask(a, targetActor, usageService, map));
+            var attackIntention = new Intention<AttackTask>(a => new AttackTask(a, targetActor, usageService));
 
 
 

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/TacticalActUsageServiceTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/TacticalActUsageServiceTests.cs
@@ -9,6 +9,7 @@ using Zilon.Core.Components;
 using Zilon.Core.Persons;
 using Zilon.Core.Tactics;
 using Zilon.Core.Tactics.Spatial;
+using Zilon.Core.Tests.Common;
 using Zilon.Core.Tests.Common.Schemes;
 
 namespace Zilon.Core.Tests.Tactics
@@ -21,6 +22,7 @@ namespace Zilon.Core.Tests.Tactics
         private IPerkResolver _perkResolver;
         private ITacticalAct _act;
         private IPerson _person;
+        private IMap _map;
 
         /// <summary>
         /// Тест проверяет, что сервис использования действий если монстр стал мёртв,
@@ -31,7 +33,7 @@ namespace Zilon.Core.Tests.Tactics
         {
             // ARRANGE
 
-            var actUsageService = new TacticalActUsageService(_actUsageRandomSource, _perkResolver);
+            var actUsageService = new TacticalActUsageService(_actUsageRandomSource, _perkResolver, _map);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -44,7 +46,8 @@ namespace Zilon.Core.Tests.Tactics
 
 
             // ACT
-            actUsageService.UseOn(actor, monster, _act);
+            var usedActs = new UsedTacticalActs(new[] { _act });
+            actUsageService.UseOn(actor, monster, usedActs);
 
 
 
@@ -73,7 +76,7 @@ namespace Zilon.Core.Tests.Tactics
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(1);
             var actUsageRandomSource = actUsageRandomSourceMock.Object;
 
-            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver);
+            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _map);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -99,7 +102,8 @@ namespace Zilon.Core.Tests.Tactics
 
 
             // ACT
-            actUsageService.UseOn(actor, monster, act);
+            var usedActs = new UsedTacticalActs(new[] { act });
+            actUsageService.UseOn(actor, monster, usedActs);
 
 
 
@@ -123,7 +127,7 @@ namespace Zilon.Core.Tests.Tactics
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(1);
             var actUsageRandomSource = actUsageRandomSourceMock.Object;
 
-            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver);
+            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _map);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -151,7 +155,8 @@ namespace Zilon.Core.Tests.Tactics
 
 
             // ACT
-            actUsageService.UseOn(actor, monster, act);
+            var usedActs = new UsedTacticalActs(new[] { act });
+            actUsageService.UseOn(actor, monster, usedActs);
 
 
 
@@ -179,7 +184,7 @@ namespace Zilon.Core.Tests.Tactics
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(fakeActEfficientRoll);
             var actUsageRandomSource = actUsageRandomSourceMock.Object;
 
-            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver);
+            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _map);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -207,7 +212,8 @@ namespace Zilon.Core.Tests.Tactics
 
 
             // ACT
-            actUsageService.UseOn(actor, monster, act);
+            var usedActs = new UsedTacticalActs(new[] { act });
+            actUsageService.UseOn(actor, monster, usedActs);
 
 
 
@@ -300,6 +306,8 @@ namespace Zilon.Core.Tests.Tactics
         [SetUp]
         public void SetUp()
         {
+            _map = SquareMapFactory.Create(3);
+
             var actUsageRandomSourceMock = new Mock<ITacticalActUsageRandomSource>();
             actUsageRandomSourceMock.Setup(x => x.RollToHit()).Returns(6);
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(1);

--- a/Zilon.Core/Zilon.Core.Tests/Tactics/TacticalActUsageServiceTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/Tactics/TacticalActUsageServiceTests.cs
@@ -22,7 +22,7 @@ namespace Zilon.Core.Tests.Tactics
         private IPerkResolver _perkResolver;
         private ITacticalAct _act;
         private IPerson _person;
-        private IMap _map;
+        private ISectorManager _sectorManager;
 
         /// <summary>
         /// Тест проверяет, что сервис использования действий если монстр стал мёртв,
@@ -33,7 +33,7 @@ namespace Zilon.Core.Tests.Tactics
         {
             // ARRANGE
 
-            var actUsageService = new TacticalActUsageService(_actUsageRandomSource, _perkResolver, _map);
+            var actUsageService = new TacticalActUsageService(_actUsageRandomSource, _perkResolver, _sectorManager);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -76,7 +76,7 @@ namespace Zilon.Core.Tests.Tactics
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(1);
             var actUsageRandomSource = actUsageRandomSourceMock.Object;
 
-            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _map);
+            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _sectorManager);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -127,7 +127,7 @@ namespace Zilon.Core.Tests.Tactics
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(1);
             var actUsageRandomSource = actUsageRandomSourceMock.Object;
 
-            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _map);
+            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _sectorManager);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -184,7 +184,7 @@ namespace Zilon.Core.Tests.Tactics
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(fakeActEfficientRoll);
             var actUsageRandomSource = actUsageRandomSourceMock.Object;
 
-            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _map);
+            var actUsageService = new TacticalActUsageService(actUsageRandomSource, _perkResolver, _sectorManager);
 
             var actorMock = new Mock<IActor>();
             actorMock.SetupGet(x => x.Node).Returns(new HexNode(0, 0));
@@ -306,8 +306,6 @@ namespace Zilon.Core.Tests.Tactics
         [SetUp]
         public void SetUp()
         {
-            _map = SquareMapFactory.Create(3);
-
             var actUsageRandomSourceMock = new Mock<ITacticalActUsageRandomSource>();
             actUsageRandomSourceMock.Setup(x => x.RollToHit()).Returns(6);
             actUsageRandomSourceMock.Setup(x => x.RollEfficient(It.IsAny<Roll>())).Returns(1);
@@ -336,6 +334,17 @@ namespace Zilon.Core.Tests.Tactics
             var actMock = new Mock<ITacticalAct>();
             actMock.SetupGet(x => x.Stats).Returns(actScheme);
             _act = actMock.Object;
+
+            var sectorManagerMock = new Mock<ISectorManager>();
+            var sectorManager = sectorManagerMock.Object;
+
+            var map = SquareMapFactory.Create(3);
+            var sectorMock = new Mock<ISector>();
+            sectorMock.SetupGet(x => x.Map).Returns(map);
+            var sector = sectorMock.Object;
+            sectorManagerMock.SetupGet(x => x.CurrentSector).Returns(sector);
+
+            _sectorManager = sectorManager;
         }
     }
 }

--- a/Zilon.Core/Zilon.Core/Commands/AttackCommand.cs
+++ b/Zilon.Core/Zilon.Core/Commands/AttackCommand.cs
@@ -65,11 +65,10 @@ namespace Zilon.Core.Commands
 
         protected override void ExecuteTacticCommand()
         {
-            var map = SectorManager.CurrentSector.Map;
             var targetActorViewModel = (IActorViewModel)PlayerState.HoverViewModel;
 
             var targetActor = targetActorViewModel.Actor;
-            var intention = new Intention<AttackTask>(a => new AttackTask(a, targetActor, _tacticalActUsageService, map));
+            var intention = new Intention<AttackTask>(a => new AttackTask(a, targetActor, _tacticalActUsageService));
             PlayerState.TaskSource.Intent(intention);
         }
     }

--- a/Zilon.Core/Zilon.Core/Persons/HumanPerson.cs
+++ b/Zilon.Core/Zilon.Core/Persons/HumanPerson.cs
@@ -348,7 +348,7 @@ namespace Zilon.Core.Persons
 
             var actList = new List<ITacticalAct>();
 
-            var defaultAct = CreateTacticalAct(_defaultActScheme, Effects);
+            var defaultAct = CreateTacticalAct(_defaultActScheme, Effects, equipment: null);
             actList.Insert(0, defaultAct);
 
             foreach (var equipment in equipments)
@@ -360,7 +360,7 @@ namespace Zilon.Core.Persons
 
                 foreach (var actScheme in equipment.Acts)
                 {
-                    var act = CreateTacticalAct(actScheme, Effects);
+                    var act = CreateTacticalAct(actScheme, Effects, equipment);
 
                     actList.Insert(0, act);
                 }
@@ -369,14 +369,14 @@ namespace Zilon.Core.Persons
             return actList.ToArray();
         }
 
-        private ITacticalAct CreateTacticalAct(ITacticalActScheme scheme, EffectCollection effects)
+        private ITacticalAct CreateTacticalAct(ITacticalActScheme scheme, EffectCollection effects, Equipment equipment)
         {
             var greaterSurvivalEffect = effects.Items.OfType<SurvivalStatHazardEffect>()
                 .OrderByDescending(x => x.Level).FirstOrDefault();
 
             if (greaterSurvivalEffect == null)
             {
-                return new TacticalAct(scheme, scheme.Stats.Efficient, new Roll(6, 1));
+                return new TacticalAct(scheme, scheme.Stats.Efficient, new Roll(6, 1), equipment);
             }
             else
             {
@@ -400,7 +400,7 @@ namespace Zilon.Core.Persons
                     toHitRoll = new Roll(6, 1, modifiers);
                 }
 
-                return new TacticalAct(scheme, efficientRoll, toHitRoll);
+                return new TacticalAct(scheme, efficientRoll, toHitRoll, equipment);
             }
         }
 

--- a/Zilon.Core/Zilon.Core/Persons/ITacticalAct.cs
+++ b/Zilon.Core/Zilon.Core/Persons/ITacticalAct.cs
@@ -1,4 +1,5 @@
 ﻿using Zilon.Core.Common;
+using Zilon.Core.Props;
 using Zilon.Core.Schemes;
 
 namespace Zilon.Core.Persons
@@ -13,6 +14,11 @@ namespace Zilon.Core.Persons
         /// Схема основных характеристик тактического действия.
         /// </summary>
         ITacticalActStatsSubScheme Stats { get; }
+
+        /// <summary>
+        /// Предмет экипировки, который даёт данное действие.
+        /// </summary>
+        Equipment Equipment { get; }
 
         /// <summary>
         /// Актуальные данные об эффективности действия.

--- a/Zilon.Core/Zilon.Core/Persons/MonsterPerson.cs
+++ b/Zilon.Core/Zilon.Core/Persons/MonsterPerson.cs
@@ -15,7 +15,7 @@ namespace Zilon.Core.Persons
     {
         public int Id { get; set; }
         public int Hp { get; }
-        public IEquipmentCarrier EquipmentCarrier => throw new NotSupportedException("Для монстров не поддерживается явная экипировка");
+        public IEquipmentCarrier EquipmentCarrier => null;
 
         public ITacticalActCarrier TacticalActCarrier { get; }
 

--- a/Zilon.Core/Zilon.Core/Persons/MonsterTacticalAct.cs
+++ b/Zilon.Core/Zilon.Core/Persons/MonsterTacticalAct.cs
@@ -1,4 +1,5 @@
 ﻿using Zilon.Core.Common;
+using Zilon.Core.Props;
 using Zilon.Core.Schemes;
 
 namespace Zilon.Core.Persons
@@ -11,6 +12,7 @@ namespace Zilon.Core.Persons
         public ITacticalActStatsSubScheme Stats { get; }
         public Roll Efficient { get; }
         public Roll ToHit { get; }
+        public Equipment Equipment { get; }
 
         public MonsterTacticalAct(ITacticalActStatsSubScheme stats)
         {

--- a/Zilon.Core/Zilon.Core/Persons/TacticalAct.cs
+++ b/Zilon.Core/Zilon.Core/Persons/TacticalAct.cs
@@ -1,4 +1,9 @@
-﻿using Zilon.Core.Common;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using JetBrains.Annotations;
+
+using Zilon.Core.Common;
+using Zilon.Core.Props;
 using Zilon.Core.Schemes;
 
 namespace Zilon.Core.Persons
@@ -8,7 +13,11 @@ namespace Zilon.Core.Persons
     /// </summary>
     public class TacticalAct : ITacticalAct
     {
-        public TacticalAct(ITacticalActScheme scheme, Roll efficient, Roll toHit)
+        [ExcludeFromCodeCoverage]
+        public TacticalAct([NotNull]ITacticalActScheme scheme,
+            [NotNull] Roll efficient,
+            [NotNull] Roll toHit,
+            [NotNull] Equipment equipment)
         {
             Scheme = scheme ?? throw new System.ArgumentNullException(nameof(scheme));
 
@@ -17,12 +26,18 @@ namespace Zilon.Core.Persons
             Efficient = efficient ?? throw new System.ArgumentNullException(nameof(efficient));
 
             ToHit = toHit ?? throw new System.ArgumentNullException(nameof(toHit));
+
+            Equipment = equipment ?? throw new System.ArgumentNullException(nameof(equipment));
         }
 
         public ITacticalActStatsSubScheme Stats { get; }
 
         public ITacticalActScheme Scheme { get; }
+
         public Roll Efficient { get; }
+
         public Roll ToHit { get; }
+
+        public Equipment Equipment { get; }
     }
 }

--- a/Zilon.Core/Zilon.Core/Persons/TacticalAct.cs
+++ b/Zilon.Core/Zilon.Core/Persons/TacticalAct.cs
@@ -17,7 +17,7 @@ namespace Zilon.Core.Persons
         public TacticalAct([NotNull]ITacticalActScheme scheme,
             [NotNull] Roll efficient,
             [NotNull] Roll toHit,
-            [NotNull] Equipment equipment)
+            [CanBeNull] Equipment equipment)
         {
             Scheme = scheme ?? throw new System.ArgumentNullException(nameof(scheme));
 
@@ -27,7 +27,7 @@ namespace Zilon.Core.Persons
 
             ToHit = toHit ?? throw new System.ArgumentNullException(nameof(toHit));
 
-            Equipment = equipment ?? throw new System.ArgumentNullException(nameof(equipment));
+            Equipment = equipment;
         }
 
         public ITacticalActStatsSubScheme Stats { get; }

--- a/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
@@ -94,6 +94,7 @@ namespace Zilon.Core.Tactics.Behaviour
             }
             else
             {
+                var usedEquipmentActs = false;
                 var slots = Actor.Person.EquipmentCarrier.Slots;
                 for (var i = 0; i < slots.Length; i++)
                 {
@@ -103,7 +104,7 @@ namespace Zilon.Core.Tactics.Behaviour
                         continue;
                     }
 
-                    if ((slots[i].Types & EquipmentSlotTypes.Hand) > 0)
+                    if ((slots[i].Types & EquipmentSlotTypes.Hand) == 0)
                     {
                         continue;
                     }
@@ -112,7 +113,19 @@ namespace Zilon.Core.Tactics.Behaviour
                                         where act.Equipment == slotEquipment
                                         select act;
 
-                    yield return equipmentActs.First();
+                    var usedAct = equipmentActs.FirstOrDefault();
+
+                    if (usedAct != null)
+                    {
+                        usedEquipmentActs = true;
+
+                        yield return usedAct;
+                    }
+                }
+
+                if (!usedEquipmentActs)
+                {
+                    yield return Actor.Person.TacticalActCarrier.Acts.First();
                 }
             }
         }

--- a/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
@@ -26,54 +26,9 @@ namespace Zilon.Core.Tactics.Behaviour
                 throw new NotImplementedException("Не неализована возможность атаковать без навыков.");
             }
 
-            var mainActProcessing = true;
             var availableSlotAct = GetUsedActs();
-
-
-            foreach (var currentAct in availableSlotAct)
-            {
-                if (mainActProcessing)
-                {
-                    mainActProcessing = false;
-
-                    var targetNode = Target.Node;
-
-                    var targetIsOnLine = MapHelper.CheckNodeAvailability(_map, Actor.Node, targetNode);
-                    var isInDistance = currentAct.CheckDistance(((HexNode)Actor.Node).CubeCoords, ((HexNode)targetNode).CubeCoords);
-
-                    var canExecute = targetIsOnLine && isInDistance;
-
-                    if (!canExecute)
-                    {
-                        throw new InvalidOperationException("Задачу на атаку нельзя выполнить сквозь стены.");
-                    }
-
-                    Actor.UseAct(Target, currentAct);
-                    _actService.UseOn(Actor, Target, currentAct);
-
-                    if (currentAct.Stats.Range.Max > 1)
-                    {
-                        break;
-                    }
-                }
-                else
-                {
-                    var targetNode = Target.Node;
-
-                    var targetIsOnLine = MapHelper.CheckNodeAvailability(_map, Actor.Node, targetNode);
-                    var isInDistance = currentAct.CheckDistance(((HexNode)Actor.Node).CubeCoords, ((HexNode)targetNode).CubeCoords);
-
-                    var canExecute = targetIsOnLine && isInDistance;
-
-                    if (!canExecute)
-                    {
-                        throw new InvalidOperationException("Задачу на атаку нельзя выполнить сквозь стены.");
-                    }
-
-                    Actor.UseAct(Target, currentAct);
-                    _actService.UseOn(Actor, Target, currentAct);
-                }
-            }
+            var usedActs = new UsedTacticalActs(availableSlotAct.Take(1), availableSlotAct.Skip(1));
+            _actService.UseOn(Actor, Target, usedActs);
         }
 
         public AttackTask(IActor actor,

--- a/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
@@ -88,25 +88,32 @@ namespace Zilon.Core.Tactics.Behaviour
 
         private IEnumerable<ITacticalAct> GetUsedActs()
         {
-            var slots = Actor.Person.EquipmentCarrier.Slots;
-            for (var i = 0; i < slots.Length; i++)
+            if (Actor.Person.EquipmentCarrier == null)
             {
-                var slotEquipment = Actor.Person.EquipmentCarrier.Equipments[i];
-                if (slotEquipment == null)
+                yield return Actor.Person.TacticalActCarrier.Acts.First();
+            }
+            else
+            {
+                var slots = Actor.Person.EquipmentCarrier.Slots;
+                for (var i = 0; i < slots.Length; i++)
                 {
-                    continue;
+                    var slotEquipment = Actor.Person.EquipmentCarrier.Equipments[i];
+                    if (slotEquipment == null)
+                    {
+                        continue;
+                    }
+
+                    if ((slots[i].Types & EquipmentSlotTypes.Hand) > 0)
+                    {
+                        continue;
+                    }
+
+                    var equipmentActs = from act in Actor.Person.TacticalActCarrier.Acts
+                                        where act.Equipment == slotEquipment
+                                        select act;
+
+                    yield return equipmentActs.First();
                 }
-
-                if ((slots[i].Types & EquipmentSlotTypes.Hand) > 0)
-                {
-                    continue;
-                }
-
-                var equipmentActs = from act in Actor.Person.TacticalActCarrier.Acts
-                                    where act.Equipment == slotEquipment
-                                    select act;
-
-                yield return equipmentActs.First();
             }
         }
     }

--- a/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
@@ -10,7 +10,6 @@ namespace Zilon.Core.Tactics.Behaviour
     public class AttackTask : OneTurnActorTaskBase
     {
         private readonly ITacticalActUsageService _actService;
-        private readonly IMap _map;
 
         public IAttackTarget Target { get; }
 
@@ -33,12 +32,10 @@ namespace Zilon.Core.Tactics.Behaviour
 
         public AttackTask(IActor actor,
             IAttackTarget target,
-            ITacticalActUsageService actService,
-            IMap map) :
+            ITacticalActUsageService actService) :
             base(actor)
         {
             _actService = actService;
-            _map = map;
 
             Target = target;
         }

--- a/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/Behaviour/AttackTask.cs
@@ -28,6 +28,8 @@ namespace Zilon.Core.Tactics.Behaviour
 
             var mainActProcessing = true;
             var availableSlotAct = GetUsedActs();
+
+
             foreach (var currentAct in availableSlotAct)
             {
                 if (mainActProcessing)

--- a/Zilon.Core/Zilon.Core/Tactics/Behaviour/Bots/AgressiveLogicBase.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/Behaviour/Bots/AgressiveLogicBase.cs
@@ -114,7 +114,7 @@ namespace Zilon.Core.Tactics.Behaviour.Bots
             var isAttackAllowed = CheckAttackAvailability(_targetIntruder);
             if (isAttackAllowed)
             {
-                var attackTask = new AttackTask(Actor, _targetIntruder, _actService, Map);
+                var attackTask = new AttackTask(Actor, _targetIntruder, _actService);
                 return attackTask;
             }
             else

--- a/Zilon.Core/Zilon.Core/Tactics/ITacticalActUsageRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/ITacticalActUsageRandomSource.cs
@@ -25,5 +25,14 @@ namespace Zilon.Core.Tactics
         /// </summary>
         /// <returns> Возвращает результат броска D6. </returns>
         int RollArmorSave();
+
+        /// <summary>
+        /// Бросок проверки на использование дополнительных действий.
+        /// </summary>
+        /// <returns> Возвращает результат броска D6. </returns>
+        /// <remarks>
+        /// Используется для проверки удара вторым оружием.
+        /// </remarks>
+        int RollUseSecondaryAct();
     }
 }

--- a/Zilon.Core/Zilon.Core/Tactics/ITacticalActUsageService.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/ITacticalActUsageService.cs
@@ -1,9 +1,7 @@
-﻿using Zilon.Core.Persons;
-
-namespace Zilon.Core.Tactics
+﻿namespace Zilon.Core.Tactics
 {
     public interface ITacticalActUsageService
     {
-        void UseOn(IActor actor, IAttackTarget target, ITacticalAct act);
+        void UseOn(IActor actor, IAttackTarget target, UsedTacticalActs usedActs);
     }
 }

--- a/Zilon.Core/Zilon.Core/Tactics/TacticalActUsageRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/TacticalActUsageRandomSource.cs
@@ -48,6 +48,11 @@ namespace Zilon.Core.Tactics
             return RollD6();
         }
 
+        public int RollUseSecondaryAct()
+        {
+            return RollD6();
+        }
+
         private int RollD6()
         {
             var roll = _dice.Roll(6);

--- a/Zilon.Core/Zilon.Core/Tactics/TacticalActUsageService.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/TacticalActUsageService.cs
@@ -37,6 +37,20 @@ namespace Zilon.Core.Tactics
                     throw new InvalidOperationException("Попытка атаковать цель, находящуюся за пределами атаки.");
                 }
 
+                // проверка
+                var targetNode = Target.Node;
+
+                var targetIsOnLine = MapHelper.CheckNodeAvailability(_map, Actor.Node, targetNode);
+                var isInDistance = currentAct.CheckDistance(((HexNode)Actor.Node).CubeCoords, ((HexNode)targetNode).CubeCoords);
+
+                var canExecute = targetIsOnLine && isInDistance;
+
+                if (!canExecute)
+                {
+                    throw new InvalidOperationException("Задачу на атаку нельзя выполнить сквозь стены.");
+                }
+                // проверка
+
                 UseAct(actor, target, act);
             }
 
@@ -58,6 +72,8 @@ namespace Zilon.Core.Tactics
 
         private void UseAct(IActor actor, IAttackTarget target, ITacticalAct act)
         {
+            actor.UseAct(target, act);
+
             var tacticalActRoll = GetActEfficient(act);
 
             if (target is IActor targetActor)

--- a/Zilon.Core/Zilon.Core/Tactics/TacticalActUsageService.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/TacticalActUsageService.cs
@@ -11,15 +11,15 @@ namespace Zilon.Core.Tactics
     {
         private readonly ITacticalActUsageRandomSource _actUsageRandomSource;
         private readonly IPerkResolver _perkResolver;
-        private readonly IMap _map;
+        private readonly ISectorManager _sectorManager;
 
         public TacticalActUsageService(ITacticalActUsageRandomSource actUsageRandomSource,
             IPerkResolver perkResolver,
-            IMap map)
+            ISectorManager sectorManager)
         {
             _actUsageRandomSource = actUsageRandomSource ?? throw new ArgumentNullException(nameof(actUsageRandomSource));
             _perkResolver = perkResolver ?? throw new ArgumentNullException(nameof(perkResolver));
-            _map = map ?? throw new ArgumentNullException(nameof(map));
+            _sectorManager = sectorManager ?? throw new ArgumentNullException(nameof(sectorManager));
         }
 
         public void UseOn(IActor actor, IAttackTarget target, UsedTacticalActs usedActs)
@@ -64,7 +64,10 @@ namespace Zilon.Core.Tactics
 
             var targetNode = target.Node;
 
-            var targetIsOnLine = MapHelper.CheckNodeAvailability(_map, actor.Node, targetNode);
+            var targetIsOnLine = MapHelper.CheckNodeAvailability(_sectorManager.CurrentSector.Map,
+                actor.Node,
+                targetNode);
+
             if (!targetIsOnLine)
             {
                 throw new InvalidOperationException("Задачу на атаку нельзя выполнить сквозь стены.");

--- a/Zilon.Core/Zilon.Core/Tactics/UsedTacticalActs.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/UsedTacticalActs.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using JetBrains.Annotations;
+
+using Zilon.Core.Persons;
+
+namespace Zilon.Core.Tactics
+{
+    /// <summary>
+    /// Структура для передачи действий, применённых за один ход.
+    /// </summary>
+    public sealed class UsedTacticalActs
+    {
+        [ExcludeFromCodeCoverage]
+        public UsedTacticalActs([NotNull] [ItemNotNull] IEnumerable<ITacticalAct> primary,
+            [NotNull] [ItemNotNull] IEnumerable<ITacticalAct> secondary)
+        {
+            Primary = primary ?? throw new ArgumentNullException(nameof(primary));
+            Secondary = secondary ?? throw new ArgumentNullException(nameof(secondary));
+        }
+
+        public IEnumerable<ITacticalAct> Primary { get; }
+        public IEnumerable<ITacticalAct> Secondary { get; }
+    }
+}

--- a/Zilon.Core/Zilon.Core/Tactics/UsedTacticalActs.cs
+++ b/Zilon.Core/Zilon.Core/Tactics/UsedTacticalActs.cs
@@ -14,6 +14,13 @@ namespace Zilon.Core.Tactics
     public sealed class UsedTacticalActs
     {
         [ExcludeFromCodeCoverage]
+        public UsedTacticalActs([NotNull] [ItemNotNull] IEnumerable<ITacticalAct> primary) :
+            this(primary, new ITacticalAct[0])
+        {
+
+        }
+
+        [ExcludeFromCodeCoverage]
         public UsedTacticalActs([NotNull] [ItemNotNull] IEnumerable<ITacticalAct> primary,
             [NotNull] [ItemNotNull] IEnumerable<ITacticalAct> secondary)
         {

--- a/Zilon.Core/Zilon.Core/Zilon.Core.csproj
+++ b/Zilon.Core/Zilon.Core/Zilon.Core.csproj
@@ -353,6 +353,7 @@
     <Compile Include="Tactics\SuccessOpenContainerResult.cs" />
     <Compile Include="Tactics\TacticalActUsageService.cs" />
     <Compile Include="Tactics\UsedActEventArgs.cs" />
+    <Compile Include="Tactics\UsedTacticalActs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
Теперь можно атаковать двумя орудиями. Второе бьёт на 5+ при 1d6.

Осталось:
1. Восстановить заигноренные тесты. Для этого написать аналогичные тесты на проверку удара через стену для сервиса. А так же спеки.
2. Убрать тестовые мечи из инвентаря на клиенте.
3. Добавить визуализацию второго удара.
4. Добавить уведомление о втором ударе в лог на клиенте.