### PR TITLE
#181 Исправление стартовой экипировки

### DIFF
--- a/Zilon.Client/Assets/Zilon/Scripts/Models/SectorScene/SectorVM.cs
+++ b/Zilon.Client/Assets/Zilon/Scripts/Models/SectorScene/SectorVM.cs
@@ -416,7 +416,7 @@ internal class SectorVM : MonoBehaviour
             _personManager.SectorName = GetRandomName();
 
 
-            var classRoll = UnityEngine.Random.Range(1, 5);
+            var classRoll = UnityEngine.Random.Range(1, 6);
             switch (classRoll)
             {
                 case 1:


### PR DESCRIPTION
# Conflicts:
#	Zilon.Client/Assets/Zilon/Scripts/Models/SectorScene/SectorVM.cs

Для исправления #181.
Верхняя граница диапазона никогда не выпадала. Документацию нужно было читать.