### PR TITLE
#248 Скролл правой части модала контейнера

### DIFF
--- a/Zilon.Client/Assets/Zilon/Prefabs/Modals/ContainerModalBody.prefab
+++ b/Zilon.Client/Assets/Zilon/Prefabs/Modals/ContainerModalBody.prefab
@@ -386,7 +386,7 @@ MonoBehaviour:
   m_Content: {fileID: 8410646745342581292}
   m_Horizontal: 0
   m_Vertical: 1
-  m_MovementType: 1
+  m_MovementType: 2
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135


### PR DESCRIPTION
Для решения задачи #248 
Исправлен модал контейнера. Правая часть - часть самого контейнера. Там были неправильные настройки скролла. Из-за этого предметы скроллились и подлезали под края, даже если умещались в область модала.