### PR TITLE
#348 Исправление генерации мира

### DIFF
--- a/Zilon.Core/Zilon.BotEnvironment/Program.cs
+++ b/Zilon.Core/Zilon.BotEnvironment/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Zilon.Core/Zilon.Core.Benchmark/CreateGlobeBench.cs
+++ b/Zilon.Core/Zilon.Core.Benchmark/CreateGlobeBench.cs
@@ -15,10 +15,16 @@ namespace Zilon.Core.Benchmark
     {
         private IWorldGenerator _generator;
 
+        [Params(1, 10)]
+        public int SequenceSize;
+
         [Benchmark(Description = "CreateGlobeBench")]
         public async Task Run()
         {
-            await _generator.GenerateGlobeAsync();
+            for (int i = 0; i < SequenceSize; i++)
+            {
+                await _generator.GenerateGlobeAsync();
+            }
         }
 
         [IterationSetup]

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/App.config
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Program.cs
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using LightInject;
 using Zilon.Core.WorldGeneration;
@@ -13,16 +14,32 @@ namespace Zilon.Core.MassWorldGenerator
         static async System.Threading.Tasks.Task Main(string[] args)
         {
             var schemeCatalog = GetProgramArgument(args, "schemeCatalog");
+            var resultPath = GetProgramArgument(args, "resultPath");
 
             _globalServiceContainer = new ServiceContainer();
             _startUp = new Startup(schemeCatalog);
             _startUp.RegisterServices(_globalServiceContainer);
 
+            var startTime = DateTime.UtcNow;
+
+            var resultFolderPreffix = startTime.ToString("yyyyMMdd-HHmmss");
+            var resultFolder = Path.Combine(resultPath, resultFolderPreffix);
+            Directory.CreateDirectory(resultFolder);
+
+            var iteration = 0;
             while (true)
             {
+                iteration++;
+
                 var worldGenerator = _globalServiceContainer.GetInstance<IWorldGenerator>();
 
-                await worldGenerator.GenerateGlobeAsync();
+                var result = await worldGenerator.GenerateGlobeAsync();
+
+                var resultRealmsFile = $"realm{iteration:D5}.bmp";
+                var resultBranchesFile = $"branches{iteration:D5}.bmp";
+
+                result.Globe.Save(resultFolder, resultRealmsFile, resultBranchesFile);
+                Console.WriteLine($"Iteration {iteration:D5} complete");
             }
         }
 

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Program.cs
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Program.cs
@@ -1,12 +1,51 @@
-﻿namespace Zilon.Core.MassWorldGenerator
+﻿using System;
+using System.Linq;
+using LightInject;
+using Zilon.Core.WorldGeneration;
+
+namespace Zilon.Core.MassWorldGenerator
 {
     class Program
     {
-        static void Main(string[] args)
+        private static ServiceContainer _globalServiceContainer;
+        private static Startup _startUp;
+
+        static async System.Threading.Tasks.Task Main(string[] args)
         {
+            var schemeCatalog = GetProgramArgument(args, "schemeCatalog");
+
             _globalServiceContainer = new ServiceContainer();
-            _startUp = new Startup();
+            _startUp = new Startup(schemeCatalog);
             _startUp.RegisterServices(_globalServiceContainer);
+
+            while (true)
+            {
+                var worldGenerator = _globalServiceContainer.GetInstance<IWorldGenerator>();
+
+                await worldGenerator.GenerateGlobeAsync();
+            }
+        }
+
+        private static bool HasProgramArgument(string[] args, string testArg)
+        {
+            return args?.Select(x => x?.Trim().ToLowerInvariant()).Contains(testArg.ToLowerInvariant()) == true;
+        }
+
+        private static string GetProgramArgument(string[] args, string testArg)
+        {
+            foreach (var arg in args)
+            {
+                var components = arg.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                if (string.Equals(components[0], testArg, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    if (components.Length >= 2)
+                    {
+                        return components[1];
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Program.cs
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Program.cs
@@ -1,0 +1,12 @@
+﻿namespace Zilon.Core.MassWorldGenerator
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            _globalServiceContainer = new ServiceContainer();
+            _startUp = new Startup();
+            _startUp.RegisterServices(_globalServiceContainer);
+        }
+    }
+}

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Properties/AssemblyInfo.cs
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Zilon.Core.MassWorldGenerator")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Zilon.Core.MassWorldGenerator")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fe267c20-e743-4e58-9a74-49fe482ff058")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Startup.cs
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Startup.cs
@@ -1,19 +1,54 @@
 ﻿using LightInject;
 
-using Zilon.Emulation.Common;
+using Zilon.Core.CommonServices.Dices;
+using Zilon.Core.Schemes;
+using Zilon.Core.WorldGeneration;
 
 namespace Zilon.Core.MassWorldGenerator
 {
-    class Startup : InitialzationBase
+    public class Startup
     {
-        public override void ConfigureAux(IServiceFactory serviceFactory)
-        {
+        private readonly string _schemeCatalog;
 
+        public Startup(string schemeCatalog)
+        {
+            _schemeCatalog = schemeCatalog;
         }
 
-        protected override void RegisterBot(IServiceRegistry container)
+        public void RegisterServices(IServiceRegistry serviceRegistry)
         {
+            RegisterSchemeService(serviceRegistry);
+            RegisterAuxServices(serviceRegistry);
+            RegisterGlobeServices(serviceRegistry);
+        }
 
+        private void RegisterGlobeServices(IServiceRegistry serviceRegistry)
+        {
+            serviceRegistry.Register<IWorldGenerator, WorldGenerator>();
+        }
+
+        private void RegisterSchemeService(IServiceRegistry container)
+        {
+            container.Register<ISchemeLocator>(factory =>
+            {
+                var schemeLocator = new FileSchemeLocator(_schemeCatalog);
+
+                return schemeLocator;
+            }, new PerContainerLifetime());
+
+            container.Register<ISchemeService, SchemeService>(new PerContainerLifetime());
+
+            container.Register<ISchemeServiceHandlerFactory, SchemeServiceHandlerFactory>(new PerContainerLifetime());
+        }
+
+        /// <summary>
+        /// Подготовка дополнительных сервисов
+        /// </summary>
+        private void RegisterAuxServices(IServiceRegistry container)
+        {
+            var dice = new Dice();
+            container.Register<IDice>(factory => dice, new PerContainerLifetime());
+            
         }
     }
 }

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Startup.cs
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Startup.cs
@@ -1,0 +1,19 @@
+﻿using LightInject;
+
+using Zilon.Emulation.Common;
+
+namespace Zilon.Core.MassWorldGenerator
+{
+    class Startup : InitialzationBase
+    {
+        public override void ConfigureAux(IServiceFactory serviceFactory)
+        {
+
+        }
+
+        protected override void RegisterBot(IServiceRegistry container)
+        {
+
+        }
+    }
+}

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/Zilon.Core.MassWorldGenerator.csproj
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/Zilon.Core.MassWorldGenerator.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FE267C20-E743-4E58-9A74-49FE482FF058}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Zilon.Core.MassWorldGenerator</RootNamespace>
+    <AssemblyName>Zilon.Core.MassWorldGenerator</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LightInject, Version=5.1.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.5.1.8\lib\net46\LightInject.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Zilon.Core\Zilon.Core.csproj">
+      <Project>{93e96628-de50-42ae-a2f5-4b4b042d66e6}</Project>
+      <Name>Zilon.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Zilon.Emulation.Common\Zilon.Emulation.Common.csproj">
+      <Project>{36013151-86C1-431E-ABC6-AFF816D4E015}</Project>
+      <Name>Zilon.Emulation.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Zilon.Core/Zilon.Core.MassWorldGenerator/packages.config
+++ b/Zilon.Core/Zilon.Core.MassWorldGenerator/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LightInject" version="5.1.8" targetFramework="net46" />
+</packages>

--- a/Zilon.Core/Zilon.Core.sln
+++ b/Zilon.Core/Zilon.Core.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zilon.Emulation.Common", "Z
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zilon.Core.Benchmarks.NetCore", "Zilon.Core.Benchmarks.NetCore\Zilon.Core.Benchmarks.NetCore.csproj", "{C1CEF5A7-9767-49A7-9CB3-A88E2D2F52C3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zilon.Core.MassWorldGenerator", "Zilon.Core.MassWorldGenerator\Zilon.Core.MassWorldGenerator.csproj", "{FE267C20-E743-4E58-9A74-49FE482FF058}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,10 @@ Global
 		{C1CEF5A7-9767-49A7-9CB3-A88E2D2F52C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C1CEF5A7-9767-49A7-9CB3-A88E2D2F52C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1CEF5A7-9767-49A7-9CB3-A88E2D2F52C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE267C20-E743-4E58-9A74-49FE482FF058}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE267C20-E743-4E58-9A74-49FE482FF058}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE267C20-E743-4E58-9A74-49FE482FF058}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE267C20-E743-4E58-9A74-49FE482FF058}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -145,6 +151,7 @@ Global
 		{B0CDC661-4458-4E1E-9375-F949F3EFB567} = {65115D33-2698-4BCE-9B94-A187A740CDE0}
 		{36013151-86C1-431E-ABC6-AFF816D4E015} = {49B389A3-F804-4C6C-B6E1-B68A5F309A7D}
 		{C1CEF5A7-9767-49A7-9CB3-A88E2D2F52C3} = {67CFF0E1-4DD5-4EFF-991D-3B745796992A}
+		{FE267C20-E743-4E58-9A74-49FE482FF058} = {49B389A3-F804-4C6C-B6E1-B68A5F309A7D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CFF0449A-4E54-4D58-A6EB-852BCB6866BE}

--- a/Zilon.Core/Zilon.Core/WorldGeneration/AgentCards/CreateLocality.cs
+++ b/Zilon.Core/Zilon.Core/WorldGeneration/AgentCards/CreateLocality.cs
@@ -18,6 +18,14 @@ namespace Zilon.Core.WorldGeneration.AgentCards
 
         public bool CanUse(Agent agent, Globe globe)
         {
+            // Можем выполнять захват, если не превышен лимит городов текущего государства.
+            var realmLocalityLimitReached = LocalityHelper.LimitIsReached(agent, globe);
+            if (realmLocalityLimitReached)
+            {
+                return false;
+            }
+
+            // Создать город можно только из населения текущего нас.пункта.
             var hasCurrentLocality = globe.LocalitiesCells.TryGetValue(agent.Location, out var currentLocality);
             if (hasCurrentLocality)
             {

--- a/Zilon.Core/Zilon.Core/WorldGeneration/AgentCards/Disciple.cs
+++ b/Zilon.Core/Zilon.Core/WorldGeneration/AgentCards/Disciple.cs
@@ -24,7 +24,11 @@ namespace Zilon.Core.WorldGeneration.AgentCards
             var highestBranchs = agent.Skills.OrderBy(x => x.Value)
                                     .Where(x => x.Value >= 1);
 
-            return highestBranchs.Any() && agent.Hp < 1;
+            var hasSpeciality = highestBranchs.Any();
+            var notDead = agent.Hp < 1;
+            var agentNotLimitReached = globe.Agents.Count() <= 120;
+
+            return hasSpeciality && notDead && agentNotLimitReached;
         }
 
         public void Use(Agent agent, Globe globe, IDice dice)
@@ -32,7 +36,7 @@ namespace Zilon.Core.WorldGeneration.AgentCards
             var highestBranchs = agent.Skills.OrderBy(x => x.Value)
                                     .Where(x => x.Value >= 1);
 
-            var agentNameGenerator = new RandomName(dice);
+            var agentNameGenerator = globe.agentNameGenerator;
 
             if (highestBranchs.Any())
             {

--- a/Zilon.Core/Zilon.Core/WorldGeneration/AgentCards/TakeLocation.cs
+++ b/Zilon.Core/Zilon.Core/WorldGeneration/AgentCards/TakeLocation.cs
@@ -21,12 +21,9 @@ namespace Zilon.Core.WorldGeneration.AgentCards
 
         public bool CanUse(Agent agent, Globe globe)
         {
-            var globeSize = globe.Terrain.Count() * globe.Terrain[0].Count();
-            var realmLocalitiesLimit = globeSize / globe.Realms.Count;
-
             // Можем выполнять захват, если не превышен лимит городов текущего государства.
-            var realmLocalities = globe.Localities.Where(x => x.Owner == agent.Realm);
-            if (realmLocalities.Count() >= realmLocalitiesLimit)
+            var realmLocalityLimitReached = LocalityHelper.LimitIsReached(agent, globe);
+            if (realmLocalityLimitReached)
             {
                 return false;
             }

--- a/Zilon.Core/Zilon.Core/WorldGeneration/Globe.cs
+++ b/Zilon.Core/Zilon.Core/WorldGeneration/Globe.cs
@@ -37,7 +37,7 @@ namespace Zilon.Core.WorldGeneration
 
         public TerrainCell HomeProvince { get; set; }
 
-        public void Save(string path)
+        public void Save(string path, string realmFileName = null, string branchFileName = null)
         {
             var branchColors = new[] { Color.Red, Color.Blue, Color.Green, Color.Yellow,
                 Color.Black, Color.Magenta, Color.Maroon, Color.LightGray };
@@ -67,8 +67,11 @@ namespace Zilon.Core.WorldGeneration
                     }
                 }
 
-                realmBmp.Bitmap.Save(Path.Combine(path, "realms.bmp"), ImageFormat.Bmp);
-                branchmBmp.Bitmap.Save(Path.Combine(path, "branches.bmp"), ImageFormat.Bmp);
+                realmFileName = realmFileName ?? "realms.bmp";
+                realmBmp.Bitmap.Save(Path.Combine(path, realmFileName), ImageFormat.Bmp);
+
+                branchFileName = branchFileName ?? "branches.bmp";
+                branchmBmp.Bitmap.Save(Path.Combine(path, branchFileName), ImageFormat.Bmp);
             }
         }
 

--- a/Zilon.Core/Zilon.Core/WorldGeneration/LocalityHelper.cs
+++ b/Zilon.Core/Zilon.Core/WorldGeneration/LocalityHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Zilon.Core.WorldGeneration
+{
+    public static class LocalityHelper
+    {
+        public static bool LimitIsReached(Agent agent, Globe globe) {
+            var globeSize = globe.Terrain.Count() * globe.Terrain[0].Count();
+            var realmLocalitiesLimit = globeSize / globe.Realms.Count;
+
+            // Можем выполнять захват, если не превышен лимит городов текущего государства.
+            var realmLocalities = globe.Localities.Where(x => x.Owner == agent.Realm);
+            if (realmLocalities.Count() >= realmLocalitiesLimit)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Zilon.Core/Zilon.Core/WorldGeneration/NameGeneration/NameGen.cs
+++ b/Zilon.Core/Zilon.Core/WorldGeneration/NameGeneration/NameGen.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Text;
+
 using Newtonsoft.Json;
+
 using Zilon.Core.CommonServices.Dices;
-using System.Reflection;
 
 namespace Zilon.Core.WorldGeneration.NameGeneration
 {

--- a/Zilon.Core/Zilon.Core/Zilon.Core.csproj
+++ b/Zilon.Core/Zilon.Core/Zilon.Core.csproj
@@ -489,6 +489,7 @@
     <Compile Include="WorldGeneration\GlobeRegionPatterns.cs" />
     <Compile Include="ProgressStoring\GlobeStorageData.cs" />
     <Compile Include="WorldGeneration\IWorldGenerator.cs" />
+    <Compile Include="WorldGeneration\LocalityHelper.cs" />
     <Compile Include="WorldGeneration\NameGeneration\CityNameGenerator.cs" />
     <Compile Include="WorldGeneration\NameGeneration\NameGen.cs" />
     <Compile Include="WorldGeneration\ScanResult.cs" />


### PR DESCRIPTION
#348 

Проблема была связана не с исключениями во время генерации мира. По какой-то причине генерация значительно замедлялась, если одна фракция захватывала мир. Введено ограничение на количество городов одной фракции.
Дополнительно в мире может быть не более 120 агентов. Это с учётом того, что каждый агент - это интерактивный персонаж. Должно будет хватить.