### PR TITLE
#413 Сокрытие кнопки инвентаря

### DIFF
--- a/Zilon.Client/Assets/Zilon/Scenes/combat.unity
+++ b/Zilon.Client/Assets/Zilon/Scenes/combat.unity
@@ -2656,7 +2656,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1793996588
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2672,10 +2672,10 @@ RectTransform:
   m_Father: {fileID: 787514921}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 65, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1793996589
 MonoBehaviour:


### PR DESCRIPTION
#413

Сейчас пока не нужна. Возможно в будущем инвентарь будет ещё раз переработан. Тогда кнопка будет возвращена.