### PR TITLE
#159 Тесты ботов

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - checkout
       - run: nuget restore Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj -SolutionDirectory ./Zilon.Core
       - run: msbuild Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj /p:Configuration=Release
-      - run: mono --debug /test45/Zilon.Core/packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe Zilon.Core/Zilon.Bot.Players.DevelopmentTests/bin/Release/Zilon.Core.Tests.dll --encoding utf-8
+      - run: mono --debug /test_bots/Zilon.Core/packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe Zilon.Core/Zilon.Bot.Players.DevelopmentTests/bin/Release/Zilon.Core.Tests.dll --encoding utf-8
   test_specflow:
     working_directory: /test_specflow
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,19 @@ jobs:
       - run: nuget restore Zilon.Core/Zilon.Core.Tests/Zilon.Core.Tests.csproj -SolutionDirectory ./Zilon.Core
       - run: msbuild Zilon.Core/Zilon.Core.Tests/Zilon.Core.Tests.csproj /p:Configuration=Release
       - run: mono --debug /test45/Zilon.Core/packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe Zilon.Core/Zilon.Core.Tests/bin/Release/Zilon.Core.Tests.dll --encoding utf-8
+  test_bots:
+    working_directory: /test_bots
+    docker:
+      - image: mono:6.0.0.313
+    environment:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OUTPUT: 1
+      ZILON_LIV_SCHEME_CATALOG: ./Zilon.Client/Assets/Resources/Schemes
+    steps:
+      - checkout
+      - run: nuget restore Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj -SolutionDirectory ./Zilon.Core
+      - run: msbuild Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj /p:Configuration=Release
+      - run: mono --debug /test45/Zilon.Core/packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe Zilon.Core/Zilon.Bot.Players.DevelopmentTests/bin/Release/Zilon.Core.Tests.dll --encoding utf-8
   test_specflow:
     working_directory: /test_specflow
     docker:
@@ -223,6 +236,15 @@ workflows:
                 - circle-ci
                 - /release-.*/
       - test_45:
+          filters:
+            branches:
+              only:
+                - master
+                - circle-ci
+                - /release-*/
+          requires:
+            - build
+      - test_bots:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,15 +244,6 @@ workflows:
                 - /release-*/
           requires:
             - build
-      - test_bots:
-          filters:
-            branches:
-              only:
-                - master
-                - circle-ci
-                - /release-*/
-          requires:
-            - build
       - test_specflow:
           filters:
             branches:
@@ -262,6 +253,17 @@ workflows:
                 - /release-*/
           requires:
             - build
+      - test_bots:
+          filters:
+            branches:
+              only:
+                - master
+                - circle-ci
+                - /release-*/
+          requires:
+            - build
+            - test_45
+            - test_specflow
       - build_Win_x64:
           filters:
             branches:
@@ -354,6 +356,11 @@ workflows:
       - test_specflow:
           requires:
             - build
+      - test_bots:
+          requires:
+            - build
+            - test_45
+            - test_specflow
       - build_Win_x64:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - checkout
       - run: nuget restore Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj -SolutionDirectory ./Zilon.Core
       - run: msbuild Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj /p:Configuration=Release
-      - run: mono --debug /test_bots/Zilon.Core/packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe Zilon.Core/Zilon.Bot.Players.DevelopmentTests/bin/Release/Zilon.Core.Tests.dll --encoding utf-8
+      - run: mono --debug /test_bots/Zilon.Core/packages/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe Zilon.Core/Zilon.Bot.Players.DevelopmentTests/bin/Release/Zilon.Bot.Players.DevelopmentTests.dll --encoding utf-8
   test_specflow:
     working_directory: /test_specflow
     docker:

--- a/Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj
+++ b/Zilon.Core/Zilon.Bot.Players.DevelopmentTests/Zilon.Bot.Players.DevelopmentTests.csproj
@@ -40,8 +40,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=2018.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.2018.2.1\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="LightInject, Version=5.1.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\LightInject.5.1.8\lib\net46\LightInject.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>

--- a/Zilon.Core/Zilon.Bot.Players.DevelopmentTests/packages.config
+++ b/Zilon.Core/Zilon.Bot.Players.DevelopmentTests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net46" />
   <package id="LightInject" version="5.1.8" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="NUnit" version="3.12.0" targetFramework="net46" />
   <package id="NUnit3TestAdapter" version="3.15.1" targetFramework="net46" />
 </packages>

--- a/Zilon.Core/Zilon.Bot.Players.DevelopmentTests/packages.config
+++ b/Zilon.Core/Zilon.Bot.Players.DevelopmentTests/packages.config
@@ -4,5 +4,6 @@
   <package id="LightInject" version="5.1.8" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="NUnit" version="3.12.0" targetFramework="net46" />
+  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net46" />
   <package id="NUnit3TestAdapter" version="3.15.1" targetFramework="net46" />
 </packages>

--- a/Zilon.Core/Zilon.Core.Tests/App.config
+++ b/Zilon.Core/Zilon.Core.Tests/App.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <appSettings configSource="AppSettings.config">
-  </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>


### PR DESCRIPTION
#159 

Теперь ночами запускаются тесты ботов

Нужно:
1. Текущие тесты либо удалить, либо сделать стабильными - зафиксировать семя рандома.
Для этого фиксировать семя для кубов. И для рандома при создании персонажа.
2. Запускать не тесты, а окружение ботов либо масс ланчер.
3. Сделать этот запуск ночным и отдельным от сборки.
4. Вынести запись консоли в логирование. На билд-сервере писать в файл. А файл складывать в артефакты. Чтобы в случае возникновения ошибки можно было загрузить полный лог.

Занесено в задачу. Пусть пока хотя бы так выполняются.