### PR TITLE
OffsetCoords исправления после статического анализа

### DIFF
--- a/Zilon.Core/Zilon.Core/OffsetCoords.cs
+++ b/Zilon.Core/Zilon.Core/OffsetCoords.cs
@@ -59,7 +59,7 @@ namespace Zilon.Core
                 return false;
             }
 
-            return left.Equals(right); ;
+            return left.Equals(right);
         }
 
         public static bool operator !=(OffsetCoords left, OffsetCoords right)

--- a/Zilon.Core/Zilon.Core/OffsetCoords.cs
+++ b/Zilon.Core/Zilon.Core/OffsetCoords.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Zilon.Core
 {
-    public sealed class OffsetCoords
+    public sealed class OffsetCoords : IEquatable<OffsetCoords>
     {
         public int X { get; }
         public int Y { get; }
@@ -18,13 +19,6 @@ namespace Zilon.Core
             return $"({X}, {Y})";
         }
 
-        public override bool Equals(object obj)
-        {
-            return obj is OffsetCoords coords &&
-                   X == coords.X &&
-                   Y == coords.Y;
-        }
-
         public override int GetHashCode()
         {
             var hashCode = 1861411795;
@@ -33,9 +27,39 @@ namespace Zilon.Core
             return hashCode;
         }
 
+        public bool Equals(OffsetCoords other)
+        {
+            if ((Object)this == (Object)other)
+            {
+                return true;
+            }
+
+            if (other is null)
+            {
+                return false;
+            }
+
+            return this.X == other.X && this.Y == other.Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is OffsetCoords coords && Equals(coords);
+        }
+
         public static bool operator ==(OffsetCoords left, OffsetCoords right)
         {
-            return EqualityComparer<OffsetCoords>.Default.Equals(left, right);
+            if ((Object)left == (Object)right)
+            {
+                return true;
+            }
+
+            if (left is null || right is null)
+            {
+                return false;
+            }
+
+            return left.Equals(right); ;
         }
 
         public static bool operator !=(OffsetCoords left, OffsetCoords right)


### PR DESCRIPTION
#523

Если решать проблему того что ругается анализатор то достаточно реализовать интерфейс IEquatable. Смотрел как реализовано это в String (https://referencesource.microsoft.com/#mscorlib/system/string.cs,372d790ddae4cbb4)

Если действительно нужны имютабельные структуры для того что сравнивать по ссылку (для производительности). То тут как понимаю немного сложнее нужно чтобы:
var c1 = new OffsetCoords(10, 10);
var c2 = new OffsetCoords(10, 10);

с1 и c2 в итоге ссылались на один объект.


Check:
var c1 = new OffsetCoords(10, 10);
var c2 = new OffsetCoords(10, 10);
 var c3 = new OffsetCoords(10, 11);

c1 == c1 True
c1 == c2 True
c1 == c3 False
c1 == null False
null == c1 False
c1.Equals(c1) True
c1.Equals(c2) True
c1.Equals('string') False
c1.Equals(null) False
c1.Equals((Object)c2) True
c1.Equals((Object)c2) False

EqualityComparer - сильно универсальный много проверок. Для объектов в итоге вызывается метод Equals. Ниже бенчмарк.

Job=Core  Runtime=Core

|           Method |     Mean |     Error |    StdDev | Rank | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|----------:|----------:|-----:|------:|------:|------:|----------:|
| EqualityComparer | 6.715 ns | 0.0253 ns | 0.0197 ns |    2 |     - |     - |     - |         - |
|           Equals | 3.933 ns | 0.0639 ns | 0.0598 ns |    1 |     - |     - |     - |         - |
