### PR TITLE
Fixes #561 Refactor duplicated code

### DIFF
--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
@@ -9,7 +9,7 @@ namespace Zilon.Core.MapGenerators.RoomStyle
 {
     public class FixCompactRoomGeneratorRandomSource : FixRoomGeneratorRandomSourceBase, IRoomGeneratorRandomSource
     {
-        public FixCompactRoomGeneratorRandomSource() : base()
+        public FixCompactRoomGeneratorRandomSource()
         {
             for (var y = 0; y < 4; y++)
             {

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
@@ -7,14 +7,10 @@ using Zilon.Core.Tactics.Spatial;
 
 namespace Zilon.Core.MapGenerators.RoomStyle
 {
-    public class FixCompactRoomGeneratorRandomSource : IRoomGeneratorRandomSource
+    public class FixCompactRoomGeneratorRandomSource : FixRoomGeneratorRandomSourceBase, IRoomGeneratorRandomSource
     {
-        private readonly List<Tuple<OffsetCoords, OffsetCoords>> _connections;
-
-        public FixCompactRoomGeneratorRandomSource()
+        public FixCompactRoomGeneratorRandomSource() : base()
         {
-            _connections = new List<Tuple<OffsetCoords, OffsetCoords>>(20);
-
             for (var y = 0; y < 4; y++)
             {
                 for (var x = 0; x < 5; x++)
@@ -22,53 +18,20 @@ namespace Zilon.Core.MapGenerators.RoomStyle
 
                     if (x == 0)
                     {
-                        _connections.Add(new Tuple<OffsetCoords, OffsetCoords>(
+                        Connections.Add(new Tuple<OffsetCoords, OffsetCoords>(
                             new OffsetCoords(x, y),
                             new OffsetCoords(x, y - 1))
                             );
                     }
                     else
                     {
-                        _connections.Add(new Tuple<OffsetCoords, OffsetCoords>(
+                        Connections.Add(new Tuple<OffsetCoords, OffsetCoords>(
                             new OffsetCoords(x, y),
                             new OffsetCoords(x - 1, y))
                             );
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Выбирает комнаты, с которыми есть соединение.
-        /// </summary>
-        /// <param name="currentRoom">Текущая комната, для которой ищуются соединённые соседи.</param>
-        /// <param name="maxNeighbors">Максимальное количество соединённых соседей.</param>
-        /// <param name="availableRooms">Набор доступных для соединения соседенй.</param>
-        /// <returns>
-        /// Возвращает целевые комнаты для соединения.
-        /// </returns>
-        [NotNull, ItemNotNull]
-        public Room[] RollConnectedRooms(Room currentRoom, int maxNeighbors, IList<Room> availableRooms)
-        {
-            if (!availableRooms.Any())
-            {
-                return new Room[0];
-            }
-
-            var currentConnection = _connections.Single(x =>
-                        x.Item1.X == currentRoom.PositionX &&
-                        x.Item1.Y == currentRoom.PositionY);
-
-            var connectedRoom = availableRooms.Single(x =>
-                x.PositionX == currentConnection.Item2.X &&
-                x.PositionY == currentConnection.Item2.Y);
-
-            return new[] { connectedRoom };
-        }
-
-        public RoomInteriorObjectMeta[] RollInteriorObjects(int roomWidth, int roomHeight)
-        {
-            return new RoomInteriorObjectMeta[0];
         }
 
         /// <summary>
@@ -109,7 +72,7 @@ namespace Zilon.Core.MapGenerators.RoomStyle
 
             foreach (var currentRoom in rooms)
             {
-                var currentConnection = _connections.Single(x =>
+                var currentConnection = Connections.Single(x =>
                         x.Item1.X == currentRoom.PositionX &&
                         x.Item1.Y == currentRoom.PositionY);
 
@@ -137,30 +100,9 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         /// <remarks>
         /// Источник рандома возвращает случайный размер комнаты в указанном диапазоне.
         /// </remarks>
-        private Size RollRoomSize(int minSize, int maxSize)
+        protected override Size RollRoomSize(int minSize, int maxSize)
         {
             return new Size(minSize, minSize);
-        }
-
-        public Size[] RollRoomSize(int minSize, int maxSize, int count)
-        {
-            var sizeList = new Size[count];
-            for (var i = 0; i < count; i++)
-            {
-                sizeList[i] = RollRoomSize(minSize, maxSize);
-            }
-
-            return sizeList;
-        }
-
-        public HexNode RollTransitionNode(IEnumerable<HexNode> openRoomNodes)
-        {
-            return openRoomNodes.First();
-        }
-
-        public IEnumerable<RoomTransition> RollTransitions(IEnumerable<RoomTransition> openTransitions)
-        {
-            return new[] { openTransitions.First() };
         }
     }
 }

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
@@ -15,7 +15,6 @@ namespace Zilon.Core.MapGenerators.RoomStyle
             {
                 for (var x = 0; x < 5; x++)
                 {
-
                     if (x == 0)
                     {
                         Connections.Add(new Tuple<OffsetCoords, OffsetCoords>(

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixCompactRoomGeneratorRandomSource.cs
@@ -41,7 +41,7 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         /// <returns>
         /// Возвращает массив координат из матрицы комнат.
         /// </returns>
-        public IEnumerable<OffsetCoords> RollRoomMatrixPositions(int roomGridSize, int roomCount)
+        public override IEnumerable<OffsetCoords> RollRoomMatrixPositions(int roomGridSize, int roomCount)
         {
             var result = new OffsetCoords[20];
 
@@ -50,38 +50,6 @@ namespace Zilon.Core.MapGenerators.RoomStyle
                 for (var x = 0; x < 5; x++)
                 {
                     result[x + y * 5] = new OffsetCoords(x, y);
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Возвращает матрицу смежности между комнатами (сеть комнат).
-        /// </summary>
-        /// <param name="rooms">Всё комнаты, которые должны быть соединены в сеть.</param>
-        /// <param name="maxNeighbors">Максимальное количество соседей у комнаты.</param>
-        /// <returns>
-        /// Возвращает словарь, представляющий собой матрицу смежности комнат.
-        /// Минимальное число соседей - 1. Максимальное - не превышает указанное в аргументе значение.
-        /// </returns>
-        public IDictionary<Room, Room[]> RollRoomNet(IEnumerable<Room> rooms, int maxNeighbors)
-        {
-            var result = new Dictionary<Room, Room[]>();
-
-            foreach (var currentRoom in rooms)
-            {
-                var currentConnection = Connections.Single(x =>
-                        x.Item1.X == currentRoom.PositionX &&
-                        x.Item1.Y == currentRoom.PositionY);
-
-                var connectedRoom = rooms.SingleOrDefault(x =>
-                    x.PositionX == currentConnection.Item2.X &&
-                    x.PositionY == currentConnection.Item2.Y);
-
-                if (connectedRoom != null)
-                {
-                    result.Add(currentRoom, new[] { connectedRoom });
                 }
             }
 

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixLargeRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixLargeRoomGeneratorRandomSource.cs
@@ -5,10 +5,9 @@ using Zilon.Core.Tactics.Spatial;
 
 namespace Zilon.Core.MapGenerators.RoomStyle
 {
-
     public class FixLargeRoomGeneratorRandomSource : FixRoomGeneratorRandomSourceBase, IRoomGeneratorRandomSource
     {
-        public FixLargeRoomGeneratorRandomSource() : base()
+        public FixLargeRoomGeneratorRandomSource()
         {
             // Все комнаты пересекаются через всё доступное пространство.
             // Каждая комната из ряда пересекается с зеркальной комнатой.

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixLargeRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixLargeRoomGeneratorRandomSource.cs
@@ -36,7 +36,7 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         /// <returns>
         /// Возвращает массив координат из матрицы комнат.
         /// </returns>
-        public IEnumerable<OffsetCoords> RollRoomMatrixPositions(int roomGridSize, int roomCount)
+        public override IEnumerable<OffsetCoords> RollRoomMatrixPositions(int roomGridSize, int roomCount)
         {
             var result = new List<OffsetCoords>(20);
 

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixLargeRoomGeneratorRandomSource.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixLargeRoomGeneratorRandomSource.cs
@@ -1,21 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using JetBrains.Annotations;
 using Zilon.Core.Tactics.Spatial;
 
 namespace Zilon.Core.MapGenerators.RoomStyle
 {
-    public class FixLargeRoomGeneratorRandomSource : IRoomGeneratorRandomSource
+
+    public class FixLargeRoomGeneratorRandomSource : FixRoomGeneratorRandomSourceBase, IRoomGeneratorRandomSource
     {
-        private readonly List<Tuple<OffsetCoords, OffsetCoords>> _connections;
-
-        public FixLargeRoomGeneratorRandomSource()
+        public FixLargeRoomGeneratorRandomSource() : base()
         {
-            // 20 комнат - это 6х6 матрица
-            _connections = new List<Tuple<OffsetCoords, OffsetCoords>>(20);
-
             // Все комнаты пересекаются через всё доступное пространство.
             // Каждая комната из ряда пересекается с зеркальной комнатой.
             // Т.е. левая верхняя с правой нижней.
@@ -27,45 +21,12 @@ namespace Zilon.Core.MapGenerators.RoomStyle
                     var current = new OffsetCoords(x, y);
                     var mirror = new OffsetCoords(5 - x, 5 - y);
 
-                    _connections.Add(new Tuple<OffsetCoords, OffsetCoords>(
+                    Connections.Add(new Tuple<OffsetCoords, OffsetCoords>(
                         current,
                         mirror)
                         );
                 }
             }
-        }
-
-        /// <summary>
-        /// Выбирает комнаты, с которыми есть соединение.
-        /// </summary>
-        /// <param name="currentRoom">Текущая комната, для которой ищуются соединённые соседи.</param>
-        /// <param name="maxNeighbors">Максимальное количество соединённых соседей.</param>
-        /// <param name="availableRooms">Набор доступных для соединения соседенй.</param>
-        /// <returns>
-        /// Возвращает целевые комнаты для соединения.
-        /// </returns>
-        [NotNull, ItemNotNull]
-        public Room[] RollConnectedRooms(Room currentRoom, int maxNeighbors, IList<Room> availableRooms)
-        {
-            if (!availableRooms.Any())
-            {
-                return new Room[0];
-            }
-
-            var currentConnection = _connections.Single(x =>
-                        x.Item1.X == currentRoom.PositionX &&
-                        x.Item1.Y == currentRoom.PositionY);
-
-            var connectedRoom = availableRooms.Single(x =>
-                x.PositionX == currentConnection.Item2.X &&
-                x.PositionY == currentConnection.Item2.Y);
-
-            return new[] { connectedRoom };
-        }
-
-        public RoomInteriorObjectMeta[] RollInteriorObjects(int roomWidth, int roomHeight)
-        {
-            return new RoomInteriorObjectMeta[0];
         }
 
         /// <summary>
@@ -96,43 +57,6 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         }
 
         /// <summary>
-        /// Возвращает матрицу смежности между комнатами (сеть комнат).
-        /// </summary>
-        /// <param name="rooms">Всё комнаты, которые должны быть соединены в сеть.</param>
-        /// <param name="maxNeighbors">Максимальное количество соседей у комнаты.</param>
-        /// <returns>
-        /// Возвращает словарь, представляющий собой матрицу смежности комнат.
-        /// Минимальное число соседей - 1. Максимальное - не превышает указанное в аргументе значение.
-        /// </returns>
-        public IDictionary<Room, Room[]> RollRoomNet(IEnumerable<Room> rooms, int maxNeighbors)
-        {
-            var result = new Dictionary<Room, Room[]>();
-
-            foreach (var currentRoom in rooms)
-            {
-                var currentConnection = _connections.SingleOrDefault(x =>
-                        x.Item1.X == currentRoom.PositionX &&
-                        x.Item1.Y == currentRoom.PositionY);
-
-                if (currentConnection == null)
-                {
-                    continue;
-                }
-
-                var connectedRoom = rooms.SingleOrDefault(x =>
-                    x.PositionX == currentConnection.Item2.X &&
-                    x.PositionY == currentConnection.Item2.Y);
-
-                if (connectedRoom != null)
-                {
-                    result.Add(currentRoom, new[] { connectedRoom });
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>
         /// Выбрасывает случайный размер комнаты.
         /// </summary>
         /// <param name="minSize">Минимальный размер комнаты.</param>
@@ -143,30 +67,9 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         /// <remarks>
         /// Источник рандома возвращает случайный размер комнаты в указанном диапазоне.
         /// </remarks>
-        private Size RollRoomSize(int minSize, int maxSize)
+        protected override Size RollRoomSize(int minSize, int maxSize)
         {
             return new Size(maxSize, maxSize);
-        }
-
-        public Size[] RollRoomSize(int minSize, int maxSize, int count)
-        {
-            var sizeList = new Size[count];
-            for (var i = 0; i < count; i++)
-            {
-                sizeList[i] = RollRoomSize(minSize, maxSize);
-            }
-
-            return sizeList;
-        }
-
-        public HexNode RollTransitionNode(IEnumerable<HexNode> openRoomNodes)
-        {
-            return openRoomNodes.First();
-        }
-
-        public IEnumerable<RoomTransition> RollTransitions(IEnumerable<RoomTransition> openTransitions)
-        {
-            return new[] { openTransitions.First() };
         }
     }
 }

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
@@ -11,7 +11,7 @@ namespace Zilon.Core.MapGenerators.RoomStyle
     {
         protected readonly List<Tuple<OffsetCoords, OffsetCoords>> Connections;
 
-        public FixRoomGeneratorRandomSourceBase()
+        protected FixRoomGeneratorRandomSourceBase()
         {
             // 20 комнат - это 6х6 матрица
             Connections = new List<Tuple<OffsetCoords, OffsetCoords>>(20);

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using JetBrains.Annotations;
+using Zilon.Core.Tactics.Spatial;
+
+namespace Zilon.Core.MapGenerators.RoomStyle
+{
+    public abstract class FixRoomGeneratorRandomSourceBase
+    {
+        protected readonly List<Tuple<OffsetCoords, OffsetCoords>> Connections;
+
+        public FixRoomGeneratorRandomSourceBase()
+        {
+            // 20 комнат - это 6х6 матрица
+            Connections = new List<Tuple<OffsetCoords, OffsetCoords>>(20);
+        }
+
+        /// <summary>
+        /// Выбирает комнаты, с которыми есть соединение.
+        /// </summary>
+        /// <param name="currentRoom">Текущая комната, для которой ищуются соединённые соседи.</param>
+        /// <param name="maxNeighbors">Максимальное количество соединённых соседей.</param>
+        /// <param name="availableRooms">Набор доступных для соединения соседенй.</param>
+        /// <returns>
+        /// Возвращает целевые комнаты для соединения.
+        /// </returns>
+        [NotNull, ItemNotNull]
+        public Room[] RollConnectedRooms(Room currentRoom, int maxNeighbors, IList<Room> availableRooms)
+        {
+            if (!availableRooms.Any())
+            {
+                return new Room[0];
+            }
+
+            var currentConnection = Connections.Single(x =>
+                        x.Item1.X == currentRoom.PositionX &&
+                        x.Item1.Y == currentRoom.PositionY);
+
+            var connectedRoom = availableRooms.Single(x =>
+                x.PositionX == currentConnection.Item2.X &&
+                x.PositionY == currentConnection.Item2.Y);
+
+            return new[] { connectedRoom };
+        }
+
+        /// <summary>
+        /// Выбрасывает случаный набор элементов интерьера комнаты.
+        /// </summary>
+        /// <param name="roomWidth">Ширина комнаты.</param>
+        /// <param name="roomHeight">Высота комнаты.</param>
+        /// <returns> Возвращает набор элементов интерьера комнаты. </returns>
+        public RoomInteriorObjectMeta[] RollInteriorObjects(int roomWidth, int roomHeight)
+        {
+            return new RoomInteriorObjectMeta[0];
+        }
+
+        /// <summary>
+        /// Возвращает матрицу смежности между комнатами (сеть комнат).
+        /// </summary>
+        /// <param name="rooms">Всё комнаты, которые должны быть соединены в сеть.</param>
+        /// <param name="maxNeighbors">Максимальное количество соседей у комнаты.</param>
+        /// <returns>
+        /// Возвращает словарь, представляющий собой матрицу смежности комнат.
+        /// Минимальное число соседей - 1. Максимальное - не превышает указанное в аргументе значение.
+        /// </returns>
+        public IDictionary<Room, Room[]> RollRoomNet(IEnumerable<Room> rooms, int maxNeighbors)
+        {
+            var result = new Dictionary<Room, Room[]>();
+
+            foreach (var currentRoom in rooms)
+            {
+                var currentConnection = Connections.SingleOrDefault(x =>
+                        x.Item1.X == currentRoom.PositionX &&
+                        x.Item1.Y == currentRoom.PositionY);
+
+                if (currentConnection == null)
+                {
+                    continue;
+                }
+
+                var connectedRoom = rooms.SingleOrDefault(x =>
+                    x.PositionX == currentConnection.Item2.X &&
+                    x.PositionY == currentConnection.Item2.Y);
+
+                if (connectedRoom != null)
+                {
+                    result.Add(currentRoom, new[] { connectedRoom });
+                }
+            }
+
+            return result;
+        }
+
+
+        public Size[] RollRoomSize(int minSize, int maxSize, int count)
+        {
+            var sizeList = new Size[count];
+            for (var i = 0; i < count; i++)
+            {
+                sizeList[i] = RollRoomSize(minSize, maxSize);
+            }
+
+            return sizeList;
+        }
+
+        public HexNode RollTransitionNode(IEnumerable<HexNode> openRoomNodes)
+        {
+            return openRoomNodes.First();
+        }
+
+
+        public IEnumerable<RoomTransition> RollTransitions(IEnumerable<RoomTransition> openTransitions)
+        {
+            return new[] { openTransitions.First() };
+        }
+
+        /// <summary>
+        /// Выбрасывает случайный размер комнаты.
+        /// </summary>
+        /// <param name="minSize">Минимальный размер комнаты.</param>
+        /// <param name="maxSize">Максимальный размер комнаты.</param>
+        /// <returns>
+        /// Возвращает размер с произвольными шириной и высотой в диапазоне (minSize, maxSize).
+        /// </returns>
+        /// <remarks>
+        /// Источник рандома возвращает случайный размер комнаты в указанном диапазоне.
+        /// </remarks>
+        protected abstract Size RollRoomSize(int minSize, int maxSize);
+    }
+}

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
@@ -7,7 +7,7 @@ using Zilon.Core.Tactics.Spatial;
 
 namespace Zilon.Core.MapGenerators.RoomStyle
 {
-    public abstract class FixRoomGeneratorRandomSourceBase
+    public abstract class FixRoomGeneratorRandomSourceBase : IRoomGeneratorRandomSource
     {
         protected readonly List<Tuple<OffsetCoords, OffsetCoords>> Connections;
 
@@ -55,6 +55,16 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         {
             return new RoomInteriorObjectMeta[0];
         }
+
+        /// <summary>
+        /// Выбрасывает случайный набор уникальных координат в матрице комнат указаной длины.
+        /// </summary>
+        /// <param name="roomGridSize">Размер матрицы комнат.</param>
+        /// <param name="roomCount">Количество комнат в секторе.</param>
+        /// <returns>
+        /// Возвращает массив координат из матрицы комнат.
+        /// </returns>
+        public abstract IEnumerable<OffsetCoords> RollRoomMatrixPositions(int roomGridSize, int roomCount);
 
         /// <summary>
         /// Возвращает матрицу смежности между комнатами (сеть комнат).

--- a/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
+++ b/Zilon.Core/Zilon.Core/MapGenerators/RoomStyle/FixRoomGeneratorRandomSourceBase.cs
@@ -93,7 +93,6 @@ namespace Zilon.Core.MapGenerators.RoomStyle
             return result;
         }
 
-
         public Size[] RollRoomSize(int minSize, int maxSize, int count)
         {
             var sizeList = new Size[count];
@@ -109,7 +108,6 @@ namespace Zilon.Core.MapGenerators.RoomStyle
         {
             return openRoomNodes.First();
         }
-
 
         public IEnumerable<RoomTransition> RollTransitions(IEnumerable<RoomTransition> openTransitions)
         {

--- a/Zilon.Core/Zilon.Core/Zilon.Core.csproj
+++ b/Zilon.Core/Zilon.Core/Zilon.Core.csproj
@@ -124,6 +124,7 @@
     <Compile Include="MapGenerators\MapRegionHelper.cs" />
     <Compile Include="MapGenerators\MonsterGenerator.cs" />
     <Compile Include="MapGenerators\MonsterGeneratorRandomSource.cs" />
+    <Compile Include="MapGenerators\RoomStyle\FixRoomGeneratorRandomSourceBase.cs" />
     <Compile Include="MapGenerators\RoomStyle\RoomGeneratorBase.cs" />
     <Compile Include="MapGenerators\RoomStyle\RoomHelper.cs" />
     <Compile Include="MapGenerators\RoomStyle\TownSectorScheme.cs" />


### PR DESCRIPTION
Moves duplicated code in `FixLargeRoomGeneratorRandomSource` and `FixCompactRoomGeneratorRandomSource` to a base class named `FixRoomGeneratorRandomSourceBase`.

Related issue #561 