### PR TITLE
Remove not needed SpecFlow packages

### DIFF
--- a/Zilon.Core/Zilon.Core.Specs/Zilon.Core.Specs.csproj
+++ b/Zilon.Core/Zilon.Core.Specs/Zilon.Core.Specs.csproj
@@ -28,9 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="SpecFlow" Version="3.5.5" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.5.5" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.5.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since SpecFlow 3.3.30 you don't need the SpecFlow NuGet package nor the SpecFlow.Tools.MsBuild.Generation, if you are using a Unit test provider NuGet package (like SpecFlow.NUnit)