### PR TITLE
Handle precisely argument exceptions in tests

### DIFF
--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
@@ -68,7 +68,7 @@ namespace Zilon.Core.Tests
                         new TestPerkScheme
                         {
                             SystemDescription = "Empty levels",
-                            Levels = Array.Empty<PerkLevelSubScheme>() 
+                            Levels = Array.Empty<PerkLevelSubScheme>()
                         },
                         1,
                         SCHEME_ARGUMENT_NAME)

--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
@@ -64,25 +64,38 @@ namespace Zilon.Core.Tests
                 yield return new TestCaseData(CreateTestPerkScheme523(), 0, TOTAL_ARGUMENT_NAME)
                     .SetDescription("Fails because total is empty");
 
-                yield return new TestCaseData(new TestPerkScheme { SystemDescription = "Empty levels", Levels = Array.Empty<PerkLevelSubScheme>() },
-                    1,
-                    SCHEME_ARGUMENT_NAME)
+                yield return new TestCaseData(
+                        new TestPerkScheme
+                            { SystemDescription = "Empty levels", Levels = Array.Empty<PerkLevelSubScheme>() },
+                        1,
+                        SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because scheme has no levels.");
 
                 yield return new TestCaseData(
-                        new TestPerkScheme { SystemDescription = "Subs is zero", Levels = new[] { new PerkLevelSubScheme { MaxValue = 0 } } },
+                        new TestPerkScheme
+                        {
+                            SystemDescription = "Subs is zero",
+                            Levels = new[] { new PerkLevelSubScheme { MaxValue = 0 } }
+                        },
                         1,
                         SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because subs sum is zero.");
 
                 yield return new TestCaseData(
-                        new TestPerkScheme { SystemDescription = "Subs is negative", Levels = new[] { new PerkLevelSubScheme { MaxValue = -1 } } },
+                        new TestPerkScheme
+                        {
+                            SystemDescription = "Subs is negative",
+                            Levels = new[] { new PerkLevelSubScheme { MaxValue = -1 } }
+                        },
                         1,
                         SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because one of the subs is negative.");
 
                 yield return new TestCaseData(
-                        new TestPerkScheme { SystemDescription = "Subs is 1", Levels = new[] { new PerkLevelSubScheme { MaxValue = 1 } } },
+                        new TestPerkScheme
+                        {
+                            SystemDescription = "Subs is 1", Levels = new[] { new PerkLevelSubScheme { MaxValue = 1 } }
+                        },
                         2,
                         TOTAL_ARGUMENT_NAME)
                     .SetDescription("Fails because subs sum less that total.");

--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
@@ -66,7 +66,10 @@ namespace Zilon.Core.Tests
 
                 yield return new TestCaseData(
                         new TestPerkScheme
-                        { SystemDescription = "Empty levels", Levels = Array.Empty<PerkLevelSubScheme>() },
+                        {
+                            SystemDescription = "Empty levels",
+                            Levels = Array.Empty<PerkLevelSubScheme>() 
+                        },
                         1,
                         SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because scheme has no levels.");

--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
@@ -48,32 +48,43 @@ namespace Zilon.Core.Tests
         /// <summary>
         /// Test cases wich fails checks.
         /// </summary>
-        public static IEnumerable ConvertTotalLevelExceptonTestCases
+        public static IEnumerable ConvertTotalLevelArgumentExceptonTestCases
         {
             get
             {
+                const string TOTAL_ARGUMENT_NAME = "totalLevel";
+                const string SCHEME_ARGUMENT_NAME = "perkScheme";
+
                 // IPerkScheme which used to convert level
                 // int testedTotalLevel - the level to convert level/sub in the perk scheme
 
-                yield return new TestCaseData(null, 0)
+                yield return new TestCaseData(null, 0, SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because scheme is null");
 
-                yield return new TestCaseData(CreateTestPerkScheme523(), 0)
+                yield return new TestCaseData(CreateTestPerkScheme523(), 0, TOTAL_ARGUMENT_NAME)
                     .SetDescription("Fails because total is empty");
 
-                yield return new TestCaseData(new TestPerkScheme { Levels = Array.Empty<PerkLevelSubScheme>() }, 0)
+                yield return new TestCaseData(new TestPerkScheme { SystemDescription = "Empty levels", Levels = Array.Empty<PerkLevelSubScheme>() },
+                    1,
+                    SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because scheme has no levels.");
 
                 yield return new TestCaseData(
-                        new TestPerkScheme { Levels = new[] { new PerkLevelSubScheme { MaxValue = 0 } } }, 1)
+                        new TestPerkScheme { SystemDescription = "Subs is zero", Levels = new[] { new PerkLevelSubScheme { MaxValue = 0 } } },
+                        1,
+                        SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because subs sum is zero.");
 
                 yield return new TestCaseData(
-                        new TestPerkScheme { Levels = new[] { new PerkLevelSubScheme { MaxValue = -1 } } }, 1)
+                        new TestPerkScheme { SystemDescription = "Subs is negative", Levels = new[] { new PerkLevelSubScheme { MaxValue = -1 } } },
+                        1,
+                        SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because one of the subs is negative.");
 
                 yield return new TestCaseData(
-                        new TestPerkScheme { Levels = new[] { new PerkLevelSubScheme { MaxValue = 1 } } }, 2)
+                        new TestPerkScheme { SystemDescription = "Subs is 1", Levels = new[] { new PerkLevelSubScheme { MaxValue = 1 } } },
+                        2,
+                        TOTAL_ARGUMENT_NAME)
                     .SetDescription("Fails because subs sum less that total.");
             }
         }

--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTestCaseSource.cs
@@ -66,7 +66,7 @@ namespace Zilon.Core.Tests
 
                 yield return new TestCaseData(
                         new TestPerkScheme
-                            { SystemDescription = "Empty levels", Levels = Array.Empty<PerkLevelSubScheme>() },
+                        { SystemDescription = "Empty levels", Levels = Array.Empty<PerkLevelSubScheme>() },
                         1,
                         SCHEME_ARGUMENT_NAME)
                     .SetDescription("Fails because scheme has no levels.");

--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTests.cs
@@ -69,7 +69,8 @@ namespace Zilon.Core.Tests
             };
 
             // ASSERT
-            act.Should().Throw<ArgumentException>().Where(exception => exception.ParamName == expectedArgumentName, $"param name must be {expectedArgumentName}");
+            act.Should().Throw<ArgumentException>().Where(exception => exception.ParamName == expectedArgumentName,
+                $"param name must be {expectedArgumentName}");
         }
 
         [Test]

--- a/Zilon.Core/Zilon.Core.Tests/PerkHelperTests.cs
+++ b/Zilon.Core/Zilon.Core.Tests/PerkHelperTests.cs
@@ -57,9 +57,10 @@ namespace Zilon.Core.Tests
 
         [Test]
         [TestCaseSource(typeof(PerkHelperTestCaseSource),
-            nameof(PerkHelperTestCaseSource.ConvertTotalLevelExceptonTestCases))]
-        public void ConvertTotalLevelToLevelSubs_FromTestCases_ThrowsExceptions(IPerkScheme perkScheme,
-            int testedTotalLevel)
+            nameof(PerkHelperTestCaseSource.ConvertTotalLevelArgumentExceptonTestCases))]
+        public void ConvertTotalLevelToLevelSubs_FromTestCases_ThrowsArgumentExceptions(IPerkScheme perkScheme,
+            int testedTotalLevel,
+            string expectedArgumentName)
         {
             // ACT
             Action act = () =>
@@ -68,7 +69,7 @@ namespace Zilon.Core.Tests
             };
 
             // ASSERT
-            act.Should().Throw<ArgumentException>();
+            act.Should().Throw<ArgumentException>().Where(exception => exception.ParamName == expectedArgumentName, $"param name must be {expectedArgumentName}");
         }
 
         [Test]

--- a/Zilon.Core/Zilon.Core/PerkHelper.cs
+++ b/Zilon.Core/Zilon.Core/PerkHelper.cs
@@ -102,13 +102,14 @@ namespace Zilon.Core
             }
             catch (ArgumentException exception)
             {
-                switch (exception.ParamName)
+                if (exception.ParamName == "total")
                 {
-                    case "total":
-                        throw new ArgumentException($"Total {totalLevel} is too big", nameof(totalLevel), exception);
 
-                    default:
-                        throw;
+                    throw new ArgumentException($"Total {totalLevel} is too big", nameof(totalLevel), exception);
+                }
+                else
+                {
+                    throw;
                 }
             }
         }

--- a/Zilon.Core/Zilon.Core/PerkHelper.cs
+++ b/Zilon.Core/Zilon.Core/PerkHelper.cs
@@ -72,6 +72,16 @@ namespace Zilon.Core
                 throw new ArgumentException("Total must be more that zero.", nameof(totalLevel));
             }
 
+            if (perkScheme.Levels is null)
+            {
+                throw new ArgumentException("Scheme's levels must not be null.", nameof(perkScheme));
+            }
+
+            if (perkScheme.Levels.Length == 0)
+            {
+                throw new ArgumentException("Scheme's levels must notbe empty.", nameof(perkScheme));
+            }
+
             foreach (var schemeLevel in perkScheme.Levels)
             {
                 if (schemeLevel.MaxValue <= 0)
@@ -82,11 +92,25 @@ namespace Zilon.Core
 
             var schemeLevels = perkScheme.Levels.Select(x => x.MaxValue).ToArray();
 
-            ConvertTotalIntoLevelSubsInner(schemeLevels, totalLevel, out var levelInner, out var subInner);
+            try
+            {
+                ConvertTotalIntoLevelSubsInner(schemeLevels, totalLevel, out var levelInner, out var subInner);
 
-            var perkLevel = new PerkLevel(levelInner, subInner);
+                var perkLevel = new PerkLevel(levelInner, subInner);
 
-            return perkLevel;
+                return perkLevel;
+            }
+            catch (ArgumentException exception)
+            {
+                switch (exception.ParamName)
+                {
+                    case "total":
+                        throw new ArgumentException($"Total {totalLevel} is too big", nameof(totalLevel), exception);
+
+                    default:
+                        throw;
+                }
+            }
         }
 
         [NotNull]

--- a/Zilon.Core/Zilon.Core/PerkHelper.cs
+++ b/Zilon.Core/Zilon.Core/PerkHelper.cs
@@ -104,13 +104,10 @@ namespace Zilon.Core
             {
                 if (exception.ParamName == "total")
                 {
-
                     throw new ArgumentException($"Total {totalLevel} is too big", nameof(totalLevel), exception);
                 }
-                else
-                {
-                    throw;
-                }
+
+                throw;
             }
         }
 


### PR DESCRIPTION
*Changes*

- Add argument name checks in fail tests of perk handler

*Checklist*

- [x] Read the contribution [guide](../blob/master/CONTRIBUTING.md) and accept the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
