### PR TITLE
Exclude dependabot branches from sonar analysis

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -11,6 +11,8 @@ on:
       - opened
       - synchronize
       - reopened
+    branches-ignore:
+      - remotes/origin/dependabot/nuget/**
 env:
     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To avoid error Environment parameter SONAR_TOKEN is required
The variable is private and invisible for dependabot.

*Changes*

- ...

*Checklist*

- [x] Read the contribution [guide](../blob/master/CONTRIBUTING.md) and accept the [code of conduct](../blob/master/CODE_OF_CONDUCT.md)
- [ ] [Readme](../blob/master/CODE_OF_CONDUCT.md) and [The Rulebook](https://last-imperial-vagabond.github.io/LAST_IMPERIAL_VAGABOND.github.io/rules/title.html) (updated or not needed)
- [ ] Tests (added, updated or not needed)
